### PR TITLE
Pass contract-instance to web3-fx.blockchain.erc20/balance-loaded event

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ This one is to obtain balance from address(es). You can also pass `:watch? true`
       
 (reg-event-fx
   :balance-loaded
-  (fn [_ [_ balance address]]
+  (fn [_ [_ balance address contract-instance]]
     {}))
 ```
 #### :web3-fx.contract/constant-fns

--- a/src/madvas/re_frame/web3_fx.cljs
+++ b/src/madvas/re_frame/web3_fx.cljs
@@ -293,14 +293,15 @@
              [instance
               :balance-of
               address
-              [:web3-fx.blockchain.erc20/balance-loaded {:address address
+              [:web3-fx.blockchain.erc20/balance-loaded {:address    address
+                                                         :instance   instance
                                                          :on-success on-success}]
               (conj on-error address)])}}))
 
 (reg-event-fx                                               ;; To keep it consisted with eth balance result order
   :web3-fx.blockchain.erc20/balance-loaded
-  (fn [db [_ {:keys [address on-success]} balance]]
-    {:dispatch (vec (concat on-success [balance address]))}))
+  (fn [db [_ {:keys [address instance on-success]} balance]]
+    {:dispatch (vec (concat on-success [balance address instance]))}))
 
 (reg-event-fx
   ;; Instead of setting up 2 events per address, would be better to use web3 topic filtering, but didn't work when I tried


### PR DESCRIPTION
This would help tracking what exact token balance is loaded.

Sorry, no tests for this. Current test suite is failing on `Method eth_compileSolidity not supported`
because it seems deprecated https://github.com/ethereum/EIPs/issues/209