### PR TITLE
Fix storing event filters in db

### DIFF
--- a/src/madvas/re_frame/web3_fx.cljs
+++ b/src/madvas/re_frame/web3_fx.cljs
@@ -100,7 +100,7 @@
 (reg-event-db
   :web3-fx.contract/assoc-event-filters
   (fn [db [_ filters-db-path filters]]
-    (assoc-in db filters-db-path filters)))
+    (update db filters-db-path merge filters)))
 
 (defn- event-stop-watching! [db db-path event-id]
   (when-let [event-filter (get-in db (conj db-path event-id))]


### PR DESCRIPTION
Merge event filters with existing ones instead of overwriting it with 'assoc'.

Caught this bug when i tried to set up multiple contract balance watchers with options:
```
   {:web3-fx.blockchain/balances
    {:instance contract
     :watch? true
     ...
     }}
```