### PR TITLE
Define earmuffed symbol as dynamic to fix compilation

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject district0x.re-frame/web3-fx "1.0.6"
+(defproject district0x.re-frame/web3-fx "1.0.7"
   :description "A re-frame effects handler for performing Ethereum Web3 API tasks"
   :url "https://github.com/district0x/re-frame-web3-fx"
   :license {:name "MIT"}

--- a/src/district0x/re_frame/web3_fx.cljs
+++ b/src/district0x/re_frame/web3_fx.cljs
@@ -7,7 +7,7 @@
     [re-frame.core :refer [reg-fx dispatch console reg-event-db reg-event-fx]])
   (:require-macros [cljs.core.async.macros :refer [go]]))
 
-(def *listeners* (atom {}))
+(def ^:dynamic *listeners* (atom {}))
 
 (defn- block-filter-opts? [x]
   (or (map? x) (string? x) (nil? x)))


### PR DESCRIPTION
Fixes the following compilation error with newer Clojure versions:
```
*listeners* not declared dynamic and thus is not dynamically rebindable,
but its name suggests otherwise. Please either indicate ^:dynamic
*listeners* or change the name
```