### PR TITLE
fix event parser when coming multiple events with same name

### DIFF
--- a/src/district0x/re_frame/web3_fx.cljs
+++ b/src/district0x/re_frame/web3_fx.cljs
@@ -113,6 +113,12 @@
                                    (reduce (fn [aggr next]
                                              (merge aggr {(keyword next) (aget args next)})) {} (js/Object.keys args))))))
 
+(defn parse-event-seq
+  [events]
+  (if (sequential? events)
+    (map parse-event events)
+    (parse-event events)))
+
 
 (defn- contract-event-dispach-fn [on-success on-error]
   (fn [err res]
@@ -353,7 +359,7 @@
     (update tx-receipt :events
             (fn [events]
               (into {} (for [[event-key event] events]
-                         [event-key (parse-event event)]))))))
+                         [event-key (parse-event-seq event)]))))))
 
 (defn safe-dispatch-one-many [re-event-one re-event-many result]
   (let [dispatch-single (fn [re-event result] (dispatch (conj (vec re-event) result)))]


### PR DESCRIPTION
When getting a tx receipt, we parse the events to include its information. The event information is usually a map of
event-name: event-info
However, if the same name is shared amount multiple events, they are included as an array of event-infos instead, such as
event-name: [event-info1, event-info2, ...]

This PR adds the support for this case.